### PR TITLE
ログファイルを1行づつ読み出すように

### DIFF
--- a/VRCImageHelper/Core/LogReader.cs
+++ b/VRCImageHelper/Core/LogReader.cs
@@ -143,9 +143,22 @@ internal class LogReader : IDisposable
                 {
                     newline = logStream.ReadLine();
                 }
-                catch (OutOfMemoryException)
+                catch (OutOfMemoryException) // 長すぎる行は読み飛ばす
                 {
-                    continue; //OOMを吐く長さの行が必要になることはないはず
+                    var lineEnd = false;
+                    while (!lineEnd)
+                    {
+                        try
+                        {
+                            logStream.ReadLine();
+                            lineEnd = true;
+                        }
+                        catch (OutOfMemoryException)
+                        {
+                            lineEnd = false;
+                        }
+                    }
+                    continue;
                 }
                 if (newline is null)
                 {

--- a/VRCImageHelper/Core/LogReader.cs
+++ b/VRCImageHelper/Core/LogReader.cs
@@ -123,22 +123,54 @@ internal class LogReader : IDisposable
         var logStream = new StreamReader(_logFile.Open(FileMode.Open, FileAccess.Read, FileShare.ReadWrite));
 
         _ = logStream.BaseStream.Seek(_head, SeekOrigin.Current);
-
-        var log = logStream.ReadToEnd().Split('\n');
-        log[0] = _lastLine + log[0];
-        for (var i = 0; i < log.Length - 1; i++)
+        while (!logStream.EndOfStream)
         {
             if (_cancellationToken.IsCancellationRequested)
-            { break; }
+            {
+                break;
+            }
 
-            var newline = log[i];
+            var newline = "";
+            if (_lastLine != "" && logStream.Peek() == '\r')
+            {
+                logStream.Read();
+                if (logStream.Peek() == '\n')
+                    logStream.Read();
+            }
+            else
+            {
+                try
+                {
+                    newline = logStream.ReadLine();
+                }
+                catch (OutOfMemoryException)
+                {
+                    continue; //OOMを吐く長さの行が必要になることはないはず
+                }
+                if (newline is null)
+                {
+                    break;
+                }
+                if (logStream.EndOfStream)
+                {
+                    logStream.BaseStream.Seek(-1, SeekOrigin.End);
+                    if (logStream.Read() != '\n')
+                    {
+                        _lastLine = newline;
+                        break;
+                    }
+                }
+            }
+
+            newline = _lastLine + newline;
+            _lastLine = "";
+
             if (newline.Length < 500 && !newline.StartsWith(" ") && newline.Trim() != "" && !newline.Contains("Error      -  ") && !newline.Contains("Warning    -  "))
             {
                 var e = new NewLineEventArgs(newline);
                 NewLine?.Invoke(this, e);
             }
         }
-        _lastLine = log[^1];
 
         _head = logStream.BaseStream.Position;
 


### PR DESCRIPTION
fix #9 (ログファイルを読み込んだときのOutOfMemoryExceptionを発生しづらくする / 発生した場合でもキャッチされるようにする)