### PR TITLE
適切(そう)なエンコードオプションをデフォルトに指定

### DIFF
--- a/VRCImageHelper/Core/Config.cs
+++ b/VRCImageHelper/Core/Config.cs
@@ -103,12 +103,14 @@ internal class ConfigManager
         return encoder switch
         {
             "" => "",
-            "libaom-av1" => "-r 1 -still-picture 1 -threads 1" + (hasAlphaChannel ? "-filter:v:1 alphaextract -map 0 -map 0" : ""),
-            "av1_qsv" => "-r 1 -preset veryslow",
-            "av1_nvenc" => "-r 1 -preset p7",
-            "av1_amf" => "-r 1 -quality high_quality",
-            "libwebp" => "-preset picture -threads 1",
-            _ => "-r 1 -threads 1",
+            "libaom-av1" => "-threads 1 -cpu-used 8 -still-picture 1 " + (hasAlphaChannel ? "-filter:v:1 alphaextract -map 0 -map 0" : ""),
+            "libsvtav1" => "-threads 1 -preset 10",
+            "librav1e" => "-threads 1 -speed 10",
+            "av1_qsv" => "-preset veryslow",
+            "av1_nvenc" => "-preset p7",
+            "av1_amf" => "-quality high_quality",
+            "libwebp" => "-threads 1 -preset picture",
+            _ => "-threads 1",
         };
     }
 }


### PR DESCRIPTION
NVEnc / AMFについてはハードウェアが手元にないため未確認
* ソフトウェア: 圧縮率より速度を優先
* ハードウェア: 圧縮率を優先
