### PR TITLE
出力先のテンプレートにカメラの種類とインスタンス情報を入れられるように・GroupインスタンスのID取得が正しくないのを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,30 +30,39 @@ VRChatのカメラで撮った画像を圧縮して、
 
     * 保存形式
         * ファイル名: 保存するときのファイル名。デフォルトの場合はVRChatの出力したファイルと同等となるはず
-            |フォーマット|置換内容|
-            |:-|:-|
-            |yyyy|年|
-            |MM|月|
-            |dd|日|
-            |hh|時|
-            |mm|分|
-            |ss|秒|
-            |fff|秒(小数点下)|
-            |XXXX|画像のピクセル数 (縦)|
-            |YYYY|画像のピクセル数 (横)|
+            | フォーマット | 置換内容 | 例 |
+            |:-|:-|:-|
+            | `yyyy` | 年 | `2025` |
+            | `MM` | 月 | `04` |
+            | `dd` | 日 | `05` |
+            | `hh` | 時 | `14` |
+            | `mm` | 分 | `19` |
+            | `ss` | 秒 | `53` |
+            | `fff` | 秒(小数点下) | `375` |
+            | `XXXX` | 画像のピクセル数 (縦) | `3840` |
+            | `YYYY` | 画像のピクセル数 (横) | `2160` |
+            | `%CAMERA%` | カメラの種類 | `VRCCamera` |
+            | `%WORLD_ID%` | ワールドID | `wrld_3208d019-7310-4c35-b12e-e4278c2689c7` |
+            | `%INSTANCE_ID%` | インスタンス番号 | `99424` |
+            | `%WORLD%` | ワールド名 | `nS／TownScaper` |
+            | `%INSTANCE_TYPE%` | インスタンスの種類 | `Friends+` |
+            | `%OWNER_ID%` | インスタンスオーナーのID | `usr_cbced732-f21a-46cd-a6a6-61990bceea14` |
+
+            例えば、`yyyy-MM\%WORLD_ID%-%WORLD%\%OWNER_ID%\%INSTANCE_TYPE%\%INSTANCE_ID%\VRChat_yyyy-MM-dd_hh-mm-ss.fff_XXXXxYYYY_%CAMERA%.jpeg` と指定したとき、
+            保存先フォルダが `D:\Pictures\VRChat` なら、`D:\Pictures\VRChat\2025-04\wrld_3208d019-7310-4c35-b12e-e4278c2689c7-nS／TownScaper\usr_cbced732-f21a-46cd-a6a6-61990bceea14\Friends+\99424\VRChat_2025-04-05_14-19-53.375_3840x2160_VRCCamera.jpeg` に保存される
 
         * 形式・品質・オプション: PNG / JPEG / WEBP / AVIFが選択できる
             * PNG: 品質設定とオプションは、無視される
             * JPEG: 品質設定は、0が最高、100が最低となる。オプションは無視される
             * WEBP / AVIF: 品質設定は、ffmpegでそれぞれのエンコーダの
-                |エンコーダ|引数|最高品質|最高圧縮|
+                | エンコーダ | 引数 | 最高品質 | 最高圧縮 |
                 |:-|:-|:-|:-|
-                |libwebp|`-quality`|0|100|
-                |libaom-av1|`-crf`|0|63|
-                |libsvtav1|`-crf`|0|63|
-                |av1_qsv|`-q`|?|?|
-                |av1_nvenc|`-cq`|1|51|
-                |av1_amf|`-qp_i`|0|255|
+                | `libwebp` | `-quality` | `0` | `100` |
+                | `libaom-av1` | `-crf` | `0` | `63` |
+                | `libsvtav1` | `-crf` | `0` | `63` |
+                | `av1_qsv` | `-q` | `?` | `?` |
+                | `av1_nvenc` | `-cq` | `1` | `51` |
+                | `av1_amf` | `-qp_i` | `0` | `255` |
 
                 CPUでlibwebp、libaom-av1とlibsvtav1を利用する場合と、Intel Arc A770でav1_qsvを利用した場合、AMD Radeon 780Mでav1_amfを利用した場合について動作を確認  
                 (NvEncでの動作は検証していませんが、デフォルトで指定しているオプションの `--pix-fmt yuv420p` の影響で、色情報が間引かれる挙動になるはずです (https://github.com/m-hayabusa/VRCImageHelper/issues/40))  

--- a/VRCImageHelper/Core/State.cs
+++ b/VRCImageHelper/Core/State.cs
@@ -5,18 +5,27 @@ using StateChecker;
 
 internal class RoomInfo
 {
-    public RoomInfo() { }
+    public RoomInfo()
+    {
+        World_id = "";
+        World_name = "";
+        Permission = "";
+        Instance_id = "";
+        Organizer = "";
+    }
     public RoomInfo(RoomInfo roomInfo)
     {
         World_id = roomInfo.World_id;
         World_name = roomInfo.World_name;
         Permission = roomInfo.Permission;
+        Instance_id = roomInfo.Instance_id;
         Organizer = roomInfo.Organizer;
     }
-    public string? World_id { get; set; }
-    public string? World_name { get; set; }
-    public string? Permission { get; set; }
-    public string? Organizer { get; set; }
+    public string World_id { get; set; }
+    public string World_name { get; set; }
+    public string Permission { get; set; }
+    public string Instance_id { get; set; }
+    public string Organizer { get; set; }
 }
 
 internal class State

--- a/VRCImageHelper/Core/StateChecker/VRChat.cs
+++ b/VRCImageHelper/Core/StateChecker/VRChat.cs
@@ -41,7 +41,7 @@ internal static class VRChat
                         State.Current.RoomInfo.Permission += "_plus";
                     }
 
-                    if (key == "groupaccessType")
+                    if (key == "groupAccessType")
                     {
                         State.Current.RoomInfo.Permission += "_" + value;
                     }

--- a/VRCImageHelper/Core/StateChecker/VRChat.cs
+++ b/VRCImageHelper/Core/StateChecker/VRChat.cs
@@ -7,13 +7,46 @@ internal static class VRChat
 {
     public static void WorldId(object sender, NewLineEventArgs e)
     {
-        var match = Regex.Match(e.Line, ".*\\[Behaviour\\] Joining (wrld_.*?):(?:.*?(private|friends|hidden|group)\\((.*?)\\))?(~canRequestInvite|~groupAccessType\\(plus\\))?");
+        var match = Regex.Match(e.Line, @".*\[Behaviour\] Joining (?<WorldName>wrld_.*?):(?<InstanceID>.*?)~(?<Options>.*)?");
         if (match.Success)
         {
-            Debug.WriteLine($"Joining {match.Groups[1]}, {match.Groups[2]}, {match.Groups[3]}, {match.Groups[4]}");
-            State.Current.RoomInfo.World_id = match.Groups[1].Value;
-            State.Current.RoomInfo.Permission = match.Groups[2].Value + (match.Groups[4].Success ? "+" : "");
-            State.Current.RoomInfo.Organizer = match.Groups[3].Value;
+            Debug.WriteLine($"Joining {match.Groups[1]}, {match.Groups[2]}, {match.Groups[3]}");
+            State.Current.RoomInfo.World_id = match.Groups["WorldName"].Value;
+            State.Current.RoomInfo.Instance_id = match.Groups["InstanceID"].Value;
+
+            if (match.Groups["Options"].Success)
+            {
+                var options = match.Groups["Options"].Value.Split("~").Select(param =>
+                {
+                    var match = Regex.Match(param, @"^(.*?)(?:\((.*?)\))?$");
+                    return new[] { match.Groups[1].Value, match.Groups[2].Value };
+                });
+
+                State.Current.RoomInfo.Permission = "public";
+                State.Current.RoomInfo.Organizer = "public";
+
+                foreach (var option in options)
+                {
+                    var key = option[0];
+                    var value = option[1];
+
+                    if (key == "private" || key == "friends" || key == "hidden" || key == "group")
+                    {
+                        State.Current.RoomInfo.Permission = key;
+                        State.Current.RoomInfo.Organizer = value;
+                    }
+
+                    if (key == "canRequestInvite")
+                    {
+                        State.Current.RoomInfo.Permission += "_plus";
+                    }
+
+                    if (key == "groupaccessType")
+                    {
+                        State.Current.RoomInfo.Permission += "_" + value;
+                    }
+                }
+            }
             State.Current.Players.Clear();
         }
     }

--- a/VRCImageHelper/Core/StateChecker/VRChat.cs
+++ b/VRCImageHelper/Core/StateChecker/VRChat.cs
@@ -10,7 +10,7 @@ internal static class VRChat
         var match = Regex.Match(e.Line, @".*\[Behaviour\] Joining (?<WorldName>wrld_.*?):(?<InstanceID>.*?)~(?<Options>.*)?");
         if (match.Success)
         {
-            Debug.WriteLine($"Joining {match.Groups[1]}, {match.Groups[2]}, {match.Groups[3]}");
+            Debug.WriteLine($"Joining {match.Groups["WorldName"]}, {match.Groups["InstanceID"]}, {match.Groups["Options"]}");
             State.Current.RoomInfo.World_id = match.Groups["WorldName"].Value;
             State.Current.RoomInfo.Instance_id = match.Groups["InstanceID"].Value;
 


### PR DESCRIPTION
fix https://github.com/m-hayabusa/VRCImageHelper/issues/56
https://github.com/m-hayabusa/VRCImageHelper/issues/55


| フォーマット | 置換内容 | 例 |
|:-|:-|:-|
| `yyyy` | 年 | `2025` |
| `MM` | 月 | `04` |
| `dd` | 日 | `05` |
| `hh` | 時 | `14` |
| `mm` | 分 | `19` |
| `ss` | 秒 | `53` |
| `fff` | 秒(小数点下) | `375` |
| `XXXX` | 画像のピクセル数 (縦) | `3840` |
| `YYYY` | 画像のピクセル数 (横) | `2160` |
| `%CAMERA%` | カメラの種類 | `VRCCamera` |
| `%WORLD_ID%` | ワールドID | `wrld_3208d019-7310-4c35-b12e-e4278c2689c7` |
| `%INSTANCE_ID%` | インスタンス番号 | `99424` |
| `%WORLD%` | ワールド名 | `nS／TownScaper` |
| `%INSTANCE_TYPE%` | インスタンスの種類 | `Friends+` |
| `%OWNER_ID%` | インスタンスオーナーのID | `usr_cbced732-f21a-46cd-a6a6-61990bceea14` |

例えば、`yyyy-MM\%WORLD_ID%-%WORLD%\%OWNER_ID%\%INSTANCE_TYPE%\%INSTANCE_ID%\VRChat_yyyy-MM-dd_hh-mm-ss.fff_XXXXxYYYY_%CAMERA%.jpeg` と指定したとき、
保存先フォルダが `D:\Pictures\VRChat` なら、`D:\Pictures\VRChat\2025-04\wrld_3208d019-7310-4c35-b12e-e4278c2689c7-nS／TownScaper\usr_cbced732-f21a-46cd-a6a6-61990bceea14\Friends+\99424\VRChat_2025-04-05_14-19-53.375_3840x2160_VRCCamera.jpeg` に保存される
